### PR TITLE
Allow queries over arbitrary net.Conn

### DIFF
--- a/livestatus.go
+++ b/livestatus.go
@@ -1,10 +1,13 @@
 // Package livestatus provides a binding to MK Livestatus sockets.
 package livestatus
 
+import "net"
+
 // Livestatus is a binding instance.
 type Livestatus struct {
 	network string
 	address string
+	dialer  func() (net.Conn, error)
 }
 
 // Query creates a new query instance on a spacific table.
@@ -17,5 +20,13 @@ func NewLivestatus(network, address string) *Livestatus {
 	return &Livestatus{
 		network: network,
 		address: address,
+	}
+}
+
+// NewLivestatusWithDialer creates a new binding that uses the net.Conn returned
+// by the provided dialer function.
+func NewLivestatusWithDialer(dialer func() (net.Conn, error)) *Livestatus {
+	return &Livestatus{
+		dialer: dialer,
 	}
 }


### PR DESCRIPTION
This introduces NewLivestatusFromDialer that takes a custom dial
function.

In our local setup we have wrapped livestatus in SSL and do some
psot connection checking of the cert name checking. The above patch
means I can wrap all that up and just do livestatus over the
resulting net.Conn

If you're interested in upstreaming this, I'll add some test etc,
I just wanted to see if you were interested in the idea
