### PR TITLE
Fix trailing ; before sending command

### DIFF
--- a/command.go
+++ b/command.go
@@ -80,6 +80,7 @@ func (c *Command) Exec() (*Response, error) {
 func (c *Command) buildCmd(t time.Time) (string, error) {
 	cmdStr := fmt.Sprintf("COMMAND [%d] %s", t.Unix(), c.cmd)
 	cmdStr = fmt.Sprintf("%s;%s", cmdStr, strings.Join(c.vals, ";"))
+	cmdStr = strings.TrimRight(cmdStr, ";")
 
 	return fmt.Sprintf("%s\n", cmdStr), nil
 }


### PR DESCRIPTION
Hello,

To have SCHEDULE_FORCED_SVC_CHECK working on icinga2, i had to fix the sent command.
In debug log, difference between the working SCHEDULE_FORCED_SVC_CHECK from icinga2web interface and the one sent by my go program, the only difference was a trailing ';' at the end of command. After i remove it, everything is ok... 