### PR TITLE
Fixes SIGSEGV when calling Close()

### DIFF
--- a/livestatus.go
+++ b/livestatus.go
@@ -17,8 +17,9 @@ type Livestatus struct {
 func (l *Livestatus) Close() error {
 	l.keepalive = false
 	if l.keepConn != nil {
+		err := l.keepConn.Close()
 		l.keepConn = nil
-		return l.keepConn.Close()
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
When I call `Close()` on the main `Livestatus` object it triggers the following `SIGSEGV`:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x4e68f5]

goroutine 1 [running]:
github.com/vbatoufflet/go-livestatus.(*Livestatus).Close(0xc420224080,
0xc420384270, 0x0)
```

The problem is that `l.keepConn` was explicitly set to `nil` before calling the `Close()` method on it.

This patch should fix the bug.

Thanks for you work BTW, it does exactly what we need at our site !