### PR TITLE
Do not set KeepAlive for non TCP connections

### DIFF
--- a/client.go
+++ b/client.go
@@ -46,7 +46,10 @@ func (c *Client) Exec(r Request) (*Response, error) {
 		}
 
 		if r.keepAlive() {
-			c.conn.(*net.TCPConn).SetKeepAlive(true)
+			switch c.network {
+			case "tcp":
+				c.conn.(*net.TCPConn).SetKeepAlive(true)
+			}
 		} else {
 			defer c.Close()
 		}


### PR DESCRIPTION
With the latest version of `master`, when using a _Unix socket_ to communicate with Livestatus, we face the following error:

```
2018/06/27 18:24:26 http: panic serving 127.0.0.1:56098: interface conversion: net.Conn is *net.UnixConn, not *net.TCPConn
goroutine 18 [running]:
net/http.(*conn).serve.func1(0xc4200e8c80)
        /opt/go/src/net/http/server.go:1721 +0xd0
panic(0x694f40, 0xc420070900)
[...]
```

This is due to the unconditional cast to a `*net.TCPConn` object in `client.go`.

This patch has been tested and fixes the issue.