### PR TITLE
Handle error when writing to Livestatus backend

### DIFF
--- a/command.go
+++ b/command.go
@@ -39,8 +39,19 @@ func (c Command) String() string {
 }
 
 func (c Command) handle(conn net.Conn) (*Response, error) {
+
+	cmd := c.String()
+	lcmd := len(cmd)
+
 	// Send query data
-	conn.Write([]byte(c.String()))
+	n, err := conn.Write([]byte(cmd))
+	if err != nil {
+		return nil, err
+	}
+
+	if n != lcmd {
+		return nil, fmt.Errorf("incomplete write to livestatus. Wrote %d bytes while %d were to be written", n, lcmd)
+	}
 
 	return nil, nil
 }

--- a/query.go
+++ b/query.go
@@ -132,8 +132,18 @@ func (q Query) String() string {
 func (q Query) handle(conn net.Conn) (*Response, error) {
 	var err error
 
+	cmd := q.String()
+	lcmd := len(cmd)
+
 	// Send query data
-	conn.Write([]byte(q.String()))
+	n, err := conn.Write([]byte(cmd))
+	if err != nil {
+		return nil, err
+	}
+
+	if n != lcmd {
+		return nil, fmt.Errorf("incomplete write to livestatus. Wrote %d bytes while %d were to be written", n, lcmd)
+	}
 
 	// Read response header
 	data := make([]byte, 16)


### PR DESCRIPTION
Previously, the return of `conn.Write()` was ignored.

This patch adds error verification and safety checks when writing to Livestatus backend.