### PR TITLE
Make query errors more useful

### DIFF
--- a/error.go
+++ b/error.go
@@ -12,3 +12,14 @@ var (
 	// ErrUnknownColumn represents an unknown column error.
 	ErrUnknownColumn = errors.New("unknown column")
 )
+
+// ParseError embeded an error with some states to help debugging
+type ParseError struct {
+	Message    string
+	FailedData []byte
+	Buffer     []byte
+}
+
+func (pe ParseError) Error() string {
+	return pe.Message
+}

--- a/query.go
+++ b/query.go
@@ -215,7 +215,7 @@ func (q Query) handle(conn net.Conn) (*Response, error) {
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			return nil, fmt.Errorf("failed to read body (buffer size: %d, remainder: %d): %v", buf.Len(), remainder, err)
+			return nil, fmt.Errorf("reading body (buffer size: %d, remainder: %d) failed: %v", buf.Len(), remainder, err)
 		}
 
 		buf.Write(bytes.TrimRight(data, "\x00"))
@@ -239,7 +239,7 @@ func (q Query) handle(conn net.Conn) (*Response, error) {
 	// Parse received data for records
 	resp.Records, err = q.parse(buf.Bytes())
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse read data as records: %v", err)
+		return nil, fmt.Errorf("parsing read data as records failed: %v", err)
 	}
 
 	return resp, nil

--- a/query.go
+++ b/query.go
@@ -255,7 +255,7 @@ func (q *Query) parse(data []byte) ([]Record, error) {
 	// Unmarshal received data
 	if err := json.Unmarshal(data, &rows); err != nil {
 		return nil, ParseError{
-			Message:    fmt.Sprintf("unmarshal JSON failed: %v", err),
+			Message:    fmt.Sprintf("unmarshalling JSON failed: %v", err),
 			FailedData: data,
 		}
 	} else if len(q.columns) == 0 && len(rows) < 2 || len(q.columns) > 0 && len(rows) < 1 {

--- a/query.go
+++ b/query.go
@@ -199,7 +199,7 @@ func (q Query) handle(conn net.Conn) (*Response, error) {
 	if err != nil {
 		return nil, ParseError{
 			Message:    fmt.Sprintf("parsing response length from header failed: %v", err),
-			FailedData: data[5:15],
+			FailedData: bytes.TrimSpace(data[5:15]),
 			Buffer:     data,
 		}
 	}


### PR DESCRIPTION
Hello,

First thank you for your library, it has been really useful.

While debugging an issue we had, which was a concurrent workers access on the socket, we had a hard time figuring out why the parsing failed. So we:
* prefixed a bunch of errors to increase the level of details
* added a new error type capable of returning not only the error message but also the data and buffer currently in use when the error occurred. It does not break anything as the type implements the error interface, just add a way to get more. For example:
```go
[...]
resp, err := c.liveclient.Exec(c.networkQuery)
	if err != nil {
		if typedError, ok := err.(livestatus.ParseError); ok {
			c.logger.Debugf("[Livestatus] network request failed: %v | Failed data: '%s' | Buffer: '%s'",
				typedError.Message, typedError.FailedData, typedError.Buffer)
		}
		err = fmt.Errorf("error while executing network request: %v", err)
		return
	}
	if resp.Status != 200 {
[...]
```